### PR TITLE
Allow someone to use the 'constraint' key in the constraint array to define what data type an array is expected to contain.

### DIFF
--- a/src/Constraint/AbstractConstraint.php
+++ b/src/Constraint/AbstractConstraint.php
@@ -12,6 +12,8 @@ abstract class AbstractConstraint {
 
     const PRIMITIVE = "";
 
+    const PRIMITIVE_IGNORED_PROPERTIES = [];
+
     final public function __construct() {
         trigger_error(get_called_class()." must not be instantiated.", E_USER_ERROR);
         exit(1);

--- a/src/Constraint/Range.php
+++ b/src/Constraint/Range.php
@@ -26,6 +26,8 @@ class Range extends AbstractConstraint implements ConstraintInterface {
 
     const PRIMITIVE = "array";
 
+    const PRIMITIVE_IGNORED_PROPERTIES = ['constraint'];
+
     protected static $operators = [
         "=",
         "<",

--- a/tests/ConstraintTest.php
+++ b/tests/ConstraintTest.php
@@ -276,7 +276,17 @@ class ConstraintTest extends \PHPUnit\Framework\TestCase {
                     "type" => "\ArrayObject"
                 ],
                 new \ArrayObject
-            ]
+            ],
+            [
+                [1,2],
+                [
+                    "type" => "array",
+                    "constraint" => [
+                        "type" => "integer"
+                    ]
+                ],
+                [1,2]
+            ],
         ];
     }
 
@@ -392,6 +402,15 @@ class ConstraintTest extends \PHPUnit\Framework\TestCase {
                     "is_nullable" => false,
                 ],
                 ""
+            ],
+            [ // testing that sub constraints are processed for array types
+                ['foo'],
+                [
+                    "type" => "array",
+                    "constraint" => [
+                        'type' => 'integer'
+                    ]
+                ]
             ],
         ];
     }


### PR DESCRIPTION
To make these changes, I had to make some adjustments to how Abstract Constraints work. The Range abstract constraint was already making use of the 'constraint' key, but in a special way. It was only using it for the last two items in the range array.

So, I added a way to ignore constraint properties when processing primitives so that the Range abstract constraint can still use the 'array' primitive as its initial check before doing its specific logic.